### PR TITLE
Pass Check URL back to the frontend in original form

### DIFF
--- a/lib/healthchecks.js
+++ b/lib/healthchecks.js
@@ -124,14 +124,14 @@ function checkFunction(protocol, hostname, port, requestID) {
       // so the HTTP check would go to http://localhost:80/ or some such URL.
 
       // Checks have relative URLs, resolve them to absolute URLs
-      checkURL          = URL.resolve(protocol + '://localhost/', checkURL);
-      const requestURL  = _.assign(URL.parse(checkURL), { host: null, port: port, hostname: hostname });
+      const absCheckURL = URL.resolve(protocol + '://localhost/', checkURL);
+      const requestURL  = _.assign(URL.parse(absCheckURL), { host: null, port: port, hostname: hostname });
       const request  = {
         hostname: requestURL.hostname,
         port:     requestURL.port,
         path:     requestURL.path,
         headers:  {
-          'Host':         URL.parse(checkURL).hostname,
+          'Host':         URL.parse(absCheckURL).hostname,
           'User-Agent':   'Mozilla/5.0 (compatible) Healthchecks http://broadly.com',
           'X-Request-Id': requestID || ''
         }

--- a/test/onfail_test.js
+++ b/test/onfail_test.js
@@ -43,7 +43,7 @@ describe('Runs checks', function() {
     it('should be notified of a failed test', function(done) {
       server.once('failed', function(failed) {
         assert.equal(failed.length, 1);
-        assert.equal(failed[0].url, 'http://localhost/error');
+        assert.equal(failed[0].url, '/error');
         assert.equal(failed[0].reason, 'error');
 
         assert(failed[0].error);
@@ -51,7 +51,7 @@ describe('Runs checks', function() {
         assert(!failed[0].statusCode);
         assert(!failed[0].body);
 
-        assert.equal(failed[0].toString(), 'http://localhost/error => socket hang up');
+        assert.equal(failed[0].toString(), '/error => socket hang up');
         done();
       });
       request(checksURL);
@@ -73,7 +73,7 @@ describe('Runs checks', function() {
 
       server.once('failed', function(failed) {
         assert.equal(failed.length, 1);
-        assert.equal(failed[0].url, 'http://localhost/timeout');
+        assert.equal(failed[0].url, '/timeout');
         assert.equal(failed[0].reason, 'timeout');
 
         assert(!failed[0].error);
@@ -81,7 +81,7 @@ describe('Runs checks', function() {
         assert(!failed[0].statusCode);
         assert(!failed[0].body);
 
-        assert.equal(failed[0].toString(), 'http://localhost/timeout => timeout');
+        assert.equal(failed[0].toString(), '/timeout => timeout');
         done();
       });
 
@@ -102,7 +102,7 @@ describe('Runs checks', function() {
     it('should be notified of a failed test', function(done) {
       server.once('failed', function(failed) {
         assert.equal(failed.length, 1);
-        assert.equal(failed[0].url, 'http://localhost/status');
+        assert.equal(failed[0].url, '/status');
         assert.equal(failed[0].reason, 'statusCode');
 
         assert(!failed[0].error);
@@ -110,7 +110,7 @@ describe('Runs checks', function() {
         assert.equal(failed[0].statusCode, 400);
         assert(!failed[0].body);
 
-        assert.equal(failed[0].toString(), 'http://localhost/status => 400');
+        assert.equal(failed[0].toString(), '/status => 400');
         done();
       });
       request(checksURL);
@@ -130,7 +130,7 @@ describe('Runs checks', function() {
     it('should be notified of a failed test', function(done) {
       server.once('failed', function(failed) {
         assert.equal(failed.length, 1);
-        assert.equal(failed[0].url, 'http://localhost/expected');
+        assert.equal(failed[0].url, '/expected');
         assert.equal(failed[0].reason, 'body');
 
         assert(!failed[0].error);
@@ -138,7 +138,7 @@ describe('Runs checks', function() {
         assert.equal(failed[0].statusCode, 200);
         assert.equal(failed[0].body, 'Expected to see foo and also bar');
 
-        assert.equal(failed[0].toString(), 'http://localhost/expected => body');
+        assert.equal(failed[0].toString(), '/expected => body');
         done();
       });
       request(checksURL);

--- a/test/user_test.js
+++ b/test/user_test.js
@@ -19,10 +19,10 @@ describe('User runs checks', function() {
     it('should see a list of passing tests', function(done) {
       browser.visit(checksURL, function() {
         browser.assert.text('h1', 'Passed');
-        browser.assert.text('.passed li:nth-of-type(1)', /http:\/\/localhost\/error \d[.\d]* ms/);
-        browser.assert.text('.passed li:nth-of-type(2)', /http:\/\/localhost\/expected \d[.\d]* ms/);
-        browser.assert.text('.passed li:nth-of-type(3)', /http:\/\/localhost\/status \d[.\d]* ms/);
-        browser.assert.text('.passed li:nth-of-type(4)', /http:\/\/localhost\/timeout \d[.\d]* ms/);
+        browser.assert.text('.passed li:nth-of-type(1)', /error \d[.\d]* ms/);
+        browser.assert.text('.passed li:nth-of-type(2)', /expected \d[.\d]* ms/);
+        browser.assert.text('.passed li:nth-of-type(3)', /status \d[.\d]* ms/);
+        browser.assert.text('.passed li:nth-of-type(4)', /timeout \d[.\d]* ms/);
         done();
       });
     });
@@ -38,7 +38,7 @@ describe('User runs checks', function() {
       browser.visit(checksURL, function() {
         browser.assert.text('h1', 'FailedPassed');
         browser.assert.elements('.failed li', 1);
-        browser.assert.text('.failed li:nth-of-type(1)', /^http:\/\/localhost\/error => socket hang up \d[.\d]* ms/);
+        browser.assert.text('.failed li:nth-of-type(1)', /error => socket hang up \d[.\d]* ms/);
         browser.assert.elements('.passed li', 3);
         done();
       });
@@ -61,7 +61,7 @@ describe('User runs checks', function() {
       browser.visit(checksURL, function() {
         browser.assert.text('h1', 'FailedPassed');
         browser.assert.elements('.failed li', 1);
-        browser.assert.text('.failed li:nth-of-type(1)', /^http:\/\/localhost\/timeout => timeout \d[.\d]* s/);
+        browser.assert.text('.failed li:nth-of-type(1)', /timeout => timeout \d[.\d]* s/);
         browser.assert.elements('.passed li', 3);
         done();
       });
@@ -82,7 +82,7 @@ describe('User runs checks', function() {
       browser.visit(checksURL, function() {
         browser.assert.text('h1', 'FailedPassed');
         browser.assert.elements('.failed li', 1);
-        browser.assert.text('.failed li:nth-of-type(1)', /^http:\/\/localhost\/status => 400 \d[.\d]* ms/);
+        browser.assert.text('.failed li:nth-of-type(1)', /status => 400 \d[.\d]* ms/);
         browser.assert.elements('.passed li', 3);
         done();
       });
@@ -103,7 +103,7 @@ describe('User runs checks', function() {
       browser.visit(checksURL, function() {
         browser.assert.text('h1', 'FailedPassed');
         browser.assert.elements('.failed li', 1);
-        browser.assert.text('.failed li:nth-of-type(1)', /^http:\/\/localhost\/expected => body \d[.\d]* ms/);
+        browser.assert.text('.failed li:nth-of-type(1)', /expected => body \d[.\d]* ms/);
         browser.assert.elements('.passed li', 3);
         done();
       });


### PR DESCRIPTION
This visibly matches the CHECKS_FILE and also allows for greater DNS flexibility from a developers perspective