### PR TITLE
Redirection and Self-signed Certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ containing the following options:
 `filename` -- The name of the checks file
 `onFailed` -- Called with array of failed checks
 `timeout`  -- Timeout slow responses
+`strictSSL` -- Defaults to true, false allows use of self-signed certificates for development
 
 You can specify the timeout in milliseconds or as a string, e.g. "3s" for 3
 seconds.
@@ -136,6 +137,7 @@ For example:
 const options = {
   filename:   CHECKS_FILE,
   timeout:    '5s',    // 5 seconds, can also pass duration in milliseconds
+  strictSSL:  (process.env.NODE_ENV === 'production') ? true : false,
   onFailed:   function(checks) {
     checks.forEach(function(check) {
       log('The following check failed:', check.url, 'reason:', check.reason);

--- a/lib/healthchecks.js
+++ b/lib/healthchecks.js
@@ -22,7 +22,7 @@ const Promise     = require('bluebird');
 const debug       = require('debug')('healthchecks');
 const File        = require('fs');
 const Handlebars  = require('handlebars');
-const HTTP        = require('http');
+const Request     = require('request');
 const ms          = require('ms');
 const Path        = require('path');
 const hrTime      = require('pretty-hrtime');
@@ -113,7 +113,7 @@ const handlebars = Handlebars.create();
 // with the properties:
 // passed  - A list of all check URLs that passed
 // failed  - A list of all check URLs that failed
-function checkFunction(protocol, hostname, port, requestID) {
+function checkFunction(protocol, hostname, port, requestID, strictSSL) {
   const checks  = this.checks;
   const timeout = this.timeout;
 
@@ -124,20 +124,24 @@ function checkFunction(protocol, hostname, port, requestID) {
       // so the HTTP check would go to http://localhost:80/ or some such URL.
 
       // Checks have relative URLs, resolve them to absolute URLs
-      const absCheckURL = URL.resolve(protocol + '://localhost/', checkURL);
-      const requestURL  = _.assign(URL.parse(absCheckURL), { host: null, port: port, hostname: hostname });
-      const request  = {
-        hostname: requestURL.hostname,
-        port:     requestURL.port,
-        path:     requestURL.path,
+      if(_.isString(port)) {hostname = hostname + ":" + port };
+      const baseURL              = protocol + "://" + hostname + '/';
+      const absCheckURL          = URL.resolve(baseURL, checkURL);
+      const reqOpts  = {
+        url: absCheckURL,
+        strictSSL: strictSSL,
         headers:  {
-          'Host':         URL.parse(absCheckURL).hostname,
+          'Host':         hostname,
           'User-Agent':   'Mozilla/5.0 (compatible) Healthchecks http://broadly.com',
           'X-Request-Id': requestID || ''
         }
       };
       const start = process.hrtime();
-      HTTP.get(request)
+      Request.get(reqOpts)
+        .on('error', function(error) {
+          const elapsed = process.hrtime(start);
+          resolve(new Outcome(checkURL, expected, error, null, null, elapsed));
+        })
         .on('response', function(response) {
           const elapsed  = process.hrtime(start);
           if (response.statusCode < 200 || response.statusCode >= 400)
@@ -152,12 +156,8 @@ function checkFunction(protocol, hostname, port, requestID) {
               resolve(new Outcome(checkURL, expected, null, response.statusCode, body, elapsed));
             });
           }
-
-        })
-        .on('error', function(error) {
-          const elapsed = process.hrtime(start);
-          resolve(new Outcome(checkURL, expected, error, null, null, elapsed));
         });
+        
 
       setTimeout(function() {
         const elapsed = process.hrtime(start);
@@ -241,16 +241,16 @@ module.exports = function healthchecks(options) {
   assert(options, 'Missing options');
 
   // Pass filename as first argument or named option
-  const filename    = (typeof options === 'string') ? options : options.filename;
+  const filename    = _.isString(options) ? options : options.filename;
   assert(filename, 'Missing checks filename');
 
   // Pass timeout as named option, or use default
-  const timeoutArg  = (typeof options !== 'string' && options.timeout) || DEFAULT_TIMEOUT;
+  const timeoutArg  = (_.isObject(options) && options.timeout) || DEFAULT_TIMEOUT;
   // If timeout argument is a string (e.g. "3d"), convert to milliseconds
-  const timeout     = (typeof timeoutArg === 'string') ? ms(timeoutArg) : +timeoutArg;
+  const timeout     = (_.isString(timeoutArg)) ? ms(timeoutArg) : + timeoutArg;
 
-  const onFailed    = options.onFailed || function() {};
-
+  const onFailed    = _.get(options, 'onFailed', function() {});
+  const strictSSL   = _.get(options, 'strictSSL', true) ? true : false;
 
   // Read all checks form the file and returns a checking function
   const runChecks = readChecks(filename, timeout);
@@ -268,12 +268,13 @@ module.exports = function healthchecks(options) {
     // may say //www.example.com/ but in development we connect to
     // 127.0.0.1:5000
     const protocol  = req.socket.encrypted ? 'https' : 'http';
-    const hostname  = req.socket.localAddress;
-    const port      = req.socket.localPort;
+    const fullHost  = req.header("Host").split(':');
+    const hostname  = fullHost[0];
+    const port      = fullHost[1];
 
     // Run all checks
     debug('Running against %s://%s:%d with request-ID %s', protocol, hostname, port, requestID);
-    runChecks(protocol, hostname, port, requestID)
+    runChecks(protocol, hostname, port, requestID, strictSSL)
       .then(function(outcomes) {
         debug('%d passed and %d failed', outcomes.passed.length, outcomes.failed.length);
 

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "handlebars": "^3.0",
     "lodash": "^3.0",
     "ms": "^0.7.1",
-    "pretty-hrtime": "^1.0.0"
+    "pretty-hrtime": "^1.0.0",
+    "request": "^2.0"
   },
   "devDependencies": {
     "eslint": "^0.21",
     "express": "^4.12",
     "mocha": "^2.2",
-    "request": "^2.0",
     "zombie": "^4.0"
   },
   "description": "Express middleware that runs health checks on your application",


### PR DESCRIPTION
This PR addresses: 
3xx redirections - using the request library follows the redirect rather than reporting a success without hitting the route. 
Self-signed certificates - adds flexibility of a strictSSL parameter to more easily allow for local development in environments with self-signed certs. 